### PR TITLE
Update Jar It! 0.1.5 -> 0.1.8

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -260,7 +260,7 @@ metafile = true
 
 [[files]]
 file = "mods/jar-it.pw.toml"
-hash = "3e8a91df3ed4158a3a8cc2887d7da7a7126bd7ab5bba8a38e41b7fadde01ea2f"
+hash = "e8253739190a68dad3ded8dc908a682570d93a024aee14056ed61b5990fdb7b5"
 metafile = true
 
 [[files]]

--- a/mods/jar-it.pw.toml
+++ b/mods/jar-it.pw.toml
@@ -1,13 +1,13 @@
 name = "Jar It!"
-filename = "jar-it-0.1.5+1.19.2.jar"
+filename = "jar-it-0.1.8+1.19.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/o6qDedG5/versions/6qRWuFGx/jar-it-0.1.5%2B1.19.2.jar"
+url = "https://cdn.modrinth.com/data/o6qDedG5/versions/pCduGEWq/jar-it-0.1.8%2B1.19.2.jar"
 hash-format = "sha1"
-hash = "cd5ebb58db7c677bb2045bd5500d3c6676338967"
+hash = "0ffb83494972fffa2eb7f8dae2c08a980e29d7c9"
 
 [update]
 [update.modrinth]
 mod-id = "o6qDedG5"
-version = "6qRWuFGx"
+version = "pCduGEWq"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f115788fdabf8fb047d93aa5c53693563ce2b4246c6c6d89b2e0b866b6419fa8"
+hash = "18621d5607f76d3b3810f444d666a9df656c656265d2afd1e30af10814a869ef"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
# This PR
This PR updates Jar It! from version 0.1.5 to version 0.1.8, incorporating many bug fixes, including: making entities and players be captured by jars properly, preventing `NullPointerException`s when handling invalid jars, and making jars usable without operator permissions.

# Testing
I have tested the new version of Jar It! with the rest of the mods in this pack on my own Modfest: Singularity testing server.