### PR TITLE
Update Jar It! 0.1.8 -> 0.1.10

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -264,7 +264,7 @@ metafile = true
 
 [[files]]
 file = "mods/jar-it.pw.toml"
-hash = "e8253739190a68dad3ded8dc908a682570d93a024aee14056ed61b5990fdb7b5"
+hash = "c5336ac93fa1998d27d832ee757a263e97a00d63bc9eb2a35cbe1fc74ed831cc"
 metafile = true
 
 [[files]]

--- a/mods/jar-it.pw.toml
+++ b/mods/jar-it.pw.toml
@@ -1,13 +1,13 @@
 name = "Jar It!"
-filename = "jar-it-0.1.8+1.19.2.jar"
+filename = "jar-it-0.1.10+1.19.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/o6qDedG5/versions/pCduGEWq/jar-it-0.1.8%2B1.19.2.jar"
+url = "https://cdn.modrinth.com/data/o6qDedG5/versions/Is4FvGmc/jar-it-0.1.10%2B1.19.2.jar"
 hash-format = "sha1"
-hash = "0ffb83494972fffa2eb7f8dae2c08a980e29d7c9"
+hash = "488e90cf49c20d01d8095e532a4e89b7e1958a6b"
 
 [update]
 [update.modrinth]
 mod-id = "o6qDedG5"
-version = "pCduGEWq"
+version = "Is4FvGmc"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6b71ec3e1cf337a7dc4a6daca10332901608c1e6e1eab38d469444a357bd4ea0"
+hash = "f7e2112c886219c3eb49116da814ab96721177f93ae9357007f50c77245100a0"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
# This PR
This PR updates Jar It! from version 0.1.8 to version 0.1.10. This adds some commands which will make it easier to build the Jar It booth.

# Testing
I have tested Jar It! `v0.1.10+1.19.2` on a local Modfest: Singularity testing server with the other mods in this modpack.