### PR TITLE
Add mostly-banned fabrication

### DIFF
--- a/config/fabrication/features.ini
+++ b/config/fabrication/features.ini
@@ -1,0 +1,2288 @@
+; Comments are indicated with a semicolon.
+
+; All toggles may be set to "banned", "false", "true", or "unset".
+; "unset" adopts the default value - what this means depends on general.category.
+; "banned" completely prevents the feature from loading, similar to "false" in
+; pre-2.0 versions of Fabrication. On servers, setting an option to banned
+; (even if it's client-only) will also prevent clients connecting to the
+; server from enabling it (if they are well-behaved; it is easy to make a
+; hacked version of Fabrication that ignores this, so don't rely on it.)
+
+; You can upgrade your config to the latest default config with all of its
+; comments without losing your settings by renaming this file to
+; "features.ini.old". You will lose any new comments or formatting, but your
+; values will be carried over.
+
+; Broad features and global settings.
+; 
+[general]
+	; Enable all features in Balance
+	; Changes to vanilla balance.
+	; 
+	category.balance=false
+
+	; Enable all features in Experiments
+	; Bad ideas given form.
+	; 
+	category.experiments=false
+
+	; Enable all features in Fixes
+	; Fixes for bugs and weird behavior.
+	; 
+	category.fixes=false
+
+	; Enable all features in Mechanics
+	; New mechanics and powerful 
+	; additions. 
+	category.mechanics=false
+
+	; Enable all features in Minor Mechanics
+	; Small additions to vanilla 
+	; mechanics. 
+	category.minor_mechanics=false
+
+	; Enable all features in Pedantry
+	; Fixes for non-problems.
+	; 
+	category.pedantry=false
+
+	; Enable all features in Tweaks
+	; Minor changes that fit with vanilla.
+	; 
+	category.tweaks=false
+
+	; Enable all features in Unsafe
+	; QoL changes that make cheating easier.
+	; 
+	category.unsafe=false
+
+	; Enable all features in Utility
+	; Useful tidbits that don't modify 
+	; gameplay. 
+	category.utility=false
+
+	; Enable all features in Weird Tweaks
+	; Opinionated changes.
+	; 
+	category.weird_tweaks=false
+
+	; Enable all features in What's Old Is New Again
+	; Forward ports of 
+	; forgotten tidbits. 
+	; 
+	category.woina=false
+
+	; Client Only
+	; 
+	; Makes the config screen darker.
+	; 
+	dark_mode=true
+
+	; Enables submitting anonymous data to a self-hosted privacy-respecting 
+	; Matomo instance run by unascribed. The following data is submitted: 
+	; Fabrication version, Minecraft version, Forge/Fabric version, Java 
+	; version, approximate window aspect ratio, OpenGL version, selected 
+	; language, operating system name (no version), currentstatus of all 
+	; features, and any mixin failures.
+	; Please enable this to give me 
+	; insight into what features people use, what features conflict, and to 
+	; help inform development decisions based on version information. 
+	; 
+	data_upload=false
+
+	; Makes the game a teensy bit faster, but requires a restart to change 
+	; features. 
+	limit_runtime_configs=true
+
+	; Client Only
+	; 
+	; Disables high-motion animations in the Fabrication 
+	; config screen. 
+	; 
+	reduced_motion=true
+
+; Fixes for bugs and weird behavior.
+; 
+[fixes]
+	; Server & Client (Client Optional)
+	; 
+	; Makes the CanDestroy and 
+	; CanPlaceOn tags be honored in survival mode instead of just adventure 
+	; mode.
+	; Only needed on server, but the experience is more seamless if 
+	; it's also on the client. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/adventure_tags_in_survival.mp4
+	adventure_tags_in_survival=banned
+
+	; Client Only
+	; 
+	; Makes textures not tick while the game is paused, 
+	; meaning animated blocks and such properly freeze instead of 
+	; continuing to animate. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/better_pause_freezing.mp4
+	better_pause_freezing=banned
+
+	; Client Only
+	; 
+	; Replaces translation strings for potion and enchantment 
+	; levels with a dynamic algorithm that supports arbitrarily large 
+	; numbers. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/boundless_levels.mp4
+	boundless_levels=banned
+
+	; Client Only
+	; 
+	; Makes "crack" particles honor item coloration, such as 
+	; leather armor dye. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/colored_crack_particles.mp4
+	colored_crack_particles=banned
+
+	; Client Only
+	; 
+	; Re-adds bubble columns having a bubble pop particle and 
+	; sound at the top.
+	; Was present in 18w07a, got removed before 1.13 
+	; release. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/bubble_column_pop.mp4
+	extra.bubble_column_pop=banned
+
+	; Server Only
+	; 
+	; Stable cacti but it will break some existing vanilla 
+	; farms. As cactus will no longer break when growing next to an 
+	; adjacent block. Using this also fixes naturally spawning cactus 
+	; farms. 
+	extra.stable_cacti_break_vanilla_compat=banned
+
+	; Server Only
+	; 
+	; Fixes a bug in Charm caused by bad assumptions that 
+	; allows generating amethyst shards if you have another mod that can 
+	; make item frames invisible, such as Fabrication's own Invisibility 
+	; Splash On Inanimates. 
+	; 
+	fix_charm_amethyst_dupe=banned
+
+	; Client Only
+	; 
+	; End portal block will render from all sides.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/fix_end_portal_render.mp4
+	fix_end_portal_render=banned
+
+	; Client Only
+	; 
+	; Render the nether portal UI texture even if player has 
+	; nausea. 
+	fix_nether_portal_nausea=banned
+
+	; Server Only
+	; 
+	; Right-clicking a furnace minecart with a non-fuel while 
+	; it's out of fuel gives it a little bit of fuel, allowing you to 
+	; "push" it.
+	; Removed some time after 17w46a (1.13 pre releases); nobody 
+	; seems to have noticed, and it wasn't announced. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/furnace_minecart_pushing.mp4
+	furnace_minecart_pushing=banned
+
+	; Client Only
+	; 
+	; Brings back the ghast "charging" animation when they're 
+	; about to fire a fireball that got broken in 1.3 and removed in 1.8, 
+	; and never worked in multiplayer. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/ghast_charging.mp4
+	ghast_charging=banned
+
+	; Client Only
+	; 
+	; Makes inanimate entities honor the "invisible" tag sent 
+	; by the server. Does nothing on its own; the server must have 
+	; something that marks inanimate entities as invisible, such as 
+	; Fabrication's own Invisibility Splash On Inanimates. 
+	; 
+	inanimates_can_be_invisible=banned
+
+	; Server Only
+	; 
+	; Through some mystical mojank reasoning mobs would 
+	; normally stop looking for the player after reaching the players last 
+	; known location, this fixes that. 
+	; 
+	melee_mobs_keep_attacking=banned
+
+	; Client Only
+	; 
+	; Allows pasting multiple lines of text into a sign. You 
+	; can also copy all the lines of a sign by holding Shift while copying. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/multiline_sign_paste.mp4
+	multiline_sign_paste=true
+
+	; Client Only
+	; 
+	; Disables the flashing effect when Night Vision is about 
+	; to run out. This effect ranges from "annoying" to "actively 
+	; dangerous". With this enabled, it just slowly fades out instead. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/no_night_vision_flash.mp4
+	no_night_vision_flash=banned
+
+	; Client Only
+	; 
+	; The player render in the inventory follows your cursor, 
+	; even if it's not inside the game window. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/omniscent_player.mp4
+	omniscent_player=banned
+
+	; Client Only
+	; 
+	; Allows players to open inventories while in a nether 
+	; portal.
+	; Vanilla originally made this change to fix a dupe exploit in 
+	; Beta. The underlying cause of this dupe was fixed a very long time 
+	; ago. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/open_inventories_in_nether_portal.mp4
+	open_inventories_in_nether_portal=banned
+
+	; Server Only
+	; 
+	; Fixes an oversight that prevents silverfish from playing 
+	; their step sound. It's also possible it's not an oversight and that 
+	; Mojang simply deemed the silverfish step sound too horrible and 
+	; dummied it out. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/silverfish_step.mp4
+	silverfish_step=banned
+
+	; Server Only
+	; 
+	; Fixes cactuses being made of Explodium due to 
+	; long-since-fixed engine limitations. In English: Makes cacti not 
+	; break themselves if a block is placed next to them. They will still 
+	; break if they *grow* into such a space, so cactus randomizers and 
+	; cactus farms still work. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/stable_cacti.mp4
+	stable_cacti=banned
+
+	; Server & Client
+	; 
+	; Makes the last attacker yaw field sync properly when 
+	; the player is damaged, instead of always being zero. Causes the 
+	; camera shake animation when being hurt to tilt away from the source 
+	; of damage instead of always tilting right.
+	; Fixes MC-26678, which is 
+	; closed as Won't Fix.
+	; Needed on both client and server, but doesn't 
+	; break vanilla clients. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/sync_attacker_yaw.mp4
+	sync_attacker_yaw=banned
+
+	; Client Only
+	; 
+	; Removes the hardcoded 60 FPS cap in menu screens, 
+	; instead using whatever you have the framerate cap set to.
+	; Primarily 
+	; added because in prior versions the cap was 30 FPS and I thought it 
+	; still was. Maybe this is nice if you have a 144Hz display? 
+	; 
+	uncap_menu_fps=banned
+
+	; Client Only
+	; 
+	; Changes player name tags to match names in the player 
+	; list. Good in combination with nickname mods like Drogtor. 
+	; 
+	; 
+	; Demonstration image: https://unascribed.com/fabrication/use_player_list_name_in_tag.png
+	use_player_list_name_in_tag=true
+
+; Useful tidbits that don't modify gameplay.
+; 
+[utility]
+	; Client Only
+	; 
+	; Makes enchanted books show the first letter of their 
+	; enchants in the bottom left, cycling through enchants every second if 
+	; they have multiple. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/books_show_enchants.mp4
+	books_show_enchants=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Adds a new CanHit tag that affects 
+	; melee attacks, bows, crossbows, and tridents. Also works on arrows 
+	; and fireworks, in which case the restrictions will be AND'd with the 
+	; restrictions of the bow or crossbow doing the firing.
+	; The tag must be 
+	; a list of strings, which may contain UUIDs that match a specific 
+	; entity or an entity type ID optionally prefixed with a ! to invert 
+	; the match.
+	; If installed on the client, adds hit information to the 
+	; tooltip. You can hide this information by creating an NBT byte set to 
+	; 1 called "HideCanHit".
+	; For example, a sword that can only hit 
+	; spiders: /give @p diamond_sword{CanHit:["spider"]}
+	; A sword that can 
+	; hit anything but creepers: /give @p 
+	; diamond_sword{CanHit:["!creeper"]} 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/canhit.mp4
+	canhit=banned
+
+	; Server & Client
+	; 
+	; Makes items that are about to despawn blink. The 
+	; despawn timer is synced from the server, so this only works if the 
+	; server also has it installed, but it means that the blinking only 
+	; happens when it should. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/despawning_items_blink.mp4
+	despawning_items_blink=banned
+
+	; Server Only
+	; 
+	; Any amount of damage done to an entity is 
+	; unconditionally fatal. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/all_damage_is_fatal.mp4
+	extra.all_damage_is_fatal=banned
+
+	; Server Only
+	; 
+	; Adds bold, strikethrough, underscore and italic markdown 
+	; to chat. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/chat_markdown.mp4
+	extra.chat_markdown=banned
+
+	; Server or Client
+	; 
+	; Prevents bee nests generating. Also disables all 
+	; bee sounds.
+	; Useful if you have a bee phobia. Makes honey 
+	; inaccessible; you may want a datapack to make it accessible again, 
+	; and/or to make empty bee nests craftable for decor.
+	; Does not delete 
+	; existing bee nests or bee entities; only fully effective in a new 
+	; world. 
+	extra.disable_bees=banned
+
+	; Server or Client
+	; 
+	; Prevents villages from generating and zombie 
+	; villagers from spawning.
+	; Villagers completely break game balance, 
+	; among other issues.
+	; Will not fully take effect unless the game is 
+	; restarted. 
+	extra.disable_villagers=banned
+
+	; Client Only
+	; 
+	; Pressing enter selects the highlighted suggestion.
+	; 
+	extra.enter_selects_highlighted_suggestion=banned
+
+	; Client Only
+	; 
+	; Item frames will not display the names of the item 
+	; inside them. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/item_frame_no_name_display.mp4
+	extra.item_frame_no_name_display=banned
+
+	; Client Only
+	; 
+	; Disables the elder guardian appearance effect upon being 
+	; inflicted with Mining Fatigue. 
+	; 
+	extra.no_guardian_jumpscare=banned
+
+	; Server Only
+	; 
+	; Sends no ping data to IPs that have not successfully 
+	; logged in in the last 7 days.
+	; Prevents scraping. There exist services 
+	; that constantly ping servers they know about and track their uptime 
+	; and who's connected, which will then turn around and store the name 
+	; history of discovered users permanently and make their cape publicly 
+	; searchable, among other things.
+	; 
+	; Does not work on 1.19.1. 
+	; 
+	; 
+	; Demonstration image: https://unascribed.com/fabrication/ping_privacy.png
+	extra.ping_privacy=true
+
+	; Client Only
+	; 
+	; Makes bee hive items show amount of contained bees.
+	; 
+	extra.show_bee_count_on_item=banned
+
+	; Server Only
+	; 
+	; Weapons can be enchanted with Silk Touch, and Silk Touch 
+	; becomes incompatible with Looting.
+	; Can be used with datapacks and 
+	; loot tables (or so I'm told). 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/weapons_accept_silk.mp4
+	extra.weapons_accept_silk=banned
+
+	; Server Only
+	; 
+	; Allows clicking on the empty output slot of a furnace to 
+	; extract the experience, instead of needing to break it. 
+	; 
+	extract_furnace_xp=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Adds /hidearmor and /showarmor 
+	; commands to hide and show your armor. Works with vanilla clients for 
+	; hiding armor from others; for hiding armor from yourself to work, 
+	; must be present on client. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/hide_armor.mp4
+	hide_armor=banned
+
+	; Server Only
+	; 
+	; Adds /i, /item, /more, and /fenchant commands.
+	; /i and 
+	; /item are shorthand for /give to yourself, and /more increases the 
+	; size of your held item's stack. /fenchant is like /enchant but it 
+	; ignores all restrictions. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/i_and_more.mp4
+	i_and_more=banned
+
+	; Server Only
+	; 
+	; Allows fine-grained control over item despawn times and 
+	; making items invulnerable to all forms of damage including the void. 
+	; You can filter by the item ID, whether the item was dropped by a 
+	; player, if the item was dropped by a player dying, what enchantments 
+	; are on the item, if the item is cursed, arbitrary NBT booleans, and 
+	; block or item tags.
+	; Configured in 
+	; config/fabrication/item_despawn.ini. 
+	; 
+	; See the default config for more info: https://github.com/unascribed/Fabrication/blob/trunk/src/main/resources/default_item_despawn_config.ini
+	item_despawn=banned
+
+	; Server Only
+	; 
+	; Adds a KillMessage NBT tag to entities and items, 
+	; allowing them to show a custom death message when they kill a player. 
+	; You can use placeholders to show the name of the killed entity, the 
+	; name of the killing entity, or the name of the killing entity's held 
+	; item, in that order.
+	; For example, "%s found a %s" would show e.g. 
+	; "unascribed found a Skeleton". You could also write this as "%1$s 
+	; found a %2$s" for the same result, or, say "A %2$s found %1$s" to 
+	; show them in the opposite order, e.g. "A Skeleton found unascribed". 
+	; The third %s or a %3$s will show the item name; if there isn't one, 
+	; [Air] will be shown. 
+	; 
+	killmessage=banned
+
+	; Server Only
+	; 
+	; Allows numeric arguments to /gamemode and /difficulty, 
+	; re-adds /toggledownfall, allows TitleCase arguments to /summon, 
+	; allows numeric arguments to commands that accept items like /give, 
+	; and re-adds shorthand to /xp.
+	; Old habits die hard. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/legacy_command_syntax.mp4
+	legacy_command_syntax=banned
+
+	; Server Only
+	; 
+	; Command suggestions for modded ids will still appear 
+	; even if the id namespace is not explicitly specified. 
+	; 
+	lenient_command_suggestions=banned
+
+	; Client Only
+	; 
+	; Links in chat are clickable. Does not work on 1.19.1.
+	; 
+	linkify_urls=banned
+
+	; Client Only
+	; 
+	; Makes entities show their entity ID as a nametag in 
+	; Creative when F3 is up. Originally a vanilla feature; was removed in 
+	; Beta 1.8 as nametags are visible through walls and it was a bit 
+	; cheaty in Survival. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/mob_ids.mp4
+	mob_ids=banned
+
+	; Server Only
+	; 
+	; Adds a /mods command listing all mods on the server. 
+	; Hovering over the mods shows their descriptions, clicking on them 
+	; takes you to their homepage if they have one.
+	; If Bukkit is not 
+	; present, also adds a /plugins command suggesting people use /mods 
+	; instead. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/mods_command.mp4
+	mods_command=banned
+
+	; Client Only
+	; 
+	; Right Mouse Button will clear text fields.
+	; 
+	rmb_clears_text_fields=banned
+
+	; Client Only
+	; 
+	; Makes bee hive tooltips show amount of contained bees.
+	; 
+	show_bee_count_tooltip=banned
+
+	; Client Only
+	; 
+	; Makes filled maps show their ID.
+	; 
+	show_map_id=banned
+
+	; Server Only
+	; 
+	; Allows you to assign or unassign various "tags" from 
+	; players via /fabrication tag. Valid tags consist of feature keys 
+	; which are living_entity scriptable. The following features are set 
+	; taggable by default: can_breathe_water, no_wandering_trader, 
+	; no_phantoms, scares_creepers, permanent_dolphins_grace, 
+	; permanent_conduit_power, fireproof, no_hunger, invisible_to_mobs. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/taggable_players.mp4
+	taggable_players=banned
+
+	; Client Only
+	; 
+	; Adds a "Toggle/Hold Sprint" keybind. Vanilla has an 
+	; accessibility option to make the Sneak key work as a toggle, since it 
+	; can be useful to have a hold and toggle button at the same time this 
+	; keybind will take the other mode of the accessibility setting. 
+	; 
+	toggle_sprint=banned
+
+	; Client Only
+	; 
+	; Adds a "Toggle Stance" keybind to switch between 
+	; standing and sneaking. Vanilla has an accessibility option to make 
+	; the existing Sneak key work as a toggle, but it can be useful to have 
+	; a hold-to-sneak and toggle-sneak button at the same time.
+	; Interacts 
+	; with Minor Mechanics > Crawling; if they are both enabled, the Toggle 
+	; Stance key will cycle between standing, sneaking, and crawling. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/toggle_stance.mp4
+	toggle_stance=banned
+
+	; Client Only
+	; 
+	; Makes tools enchanted with Silk Touch, Fortune, or 
+	; Riptide show the first letter of that enchant in the top left.
+	; Never 
+	; break an Ender Chest with the wrong tool again. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/tools_show_important_enchant.mp4
+	tools_show_important_enchant=banned
+
+	; Server Only
+	; 
+	; Adds a yeet_recipes.ini that can be used to completely 
+	; remove any recipe. 
+	; 
+	yeet_recipes=banned
+
+; Minor changes that fit with vanilla.
+; 
+[tweaks]
+	; Server & Client
+	; 
+	; Taking damage that is completely absorbed by 
+	; Absorption plays a different (custom) sound.
+	; Required on both sides, 
+	; but doesn't break vanilla clients. 
+	; 
+	alt_absorption_sound=banned
+
+	; Server Only
+	; 
+	; Reduces arrow drag in water by a fair bit to make bows 
+	; useful underwater. Not nearly as good as a trident, but usable. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/arrows_work_in_water.mp4
+	arrows_work_in_water=banned
+
+	; Server Only
+	; 
+	; Makes walking through berry bushes not deal damage.
+	; 
+	bush_walk_doesnt_hurt=banned
+
+	; Server Only
+	; 
+	; Makes walking through berry bushes when sneaking not 
+	; deal damage. 
+	; 
+	bush_walk_doesnt_hurt_when_sneaking=banned
+
+	; Server Only
+	; 
+	; Makes walking through berry bushes with both leggings 
+	; and boots equipped not deal damage. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/bush_walk_doesnt_hurt_with_armor.mp4
+	bush_walk_doesnt_hurt_with_armor=banned
+
+	; Server Only
+	; 
+	; Makes touching the side of a cactus (not walking on top 
+	; of one) with a chestplate equipped not deal damage. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/cactus_brush_doesnt_hurt_with_chest.mp4
+	cactus_brush_doesnt_hurt_with_chest=banned
+
+	; Server Only
+	; 
+	; Makes walking on top of a cactus (not touching the side 
+	; of one) with boots equipped not deal damage. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/cactus_walk_doesnt_hurt_with_boots.mp4
+	cactus_walk_doesnt_hurt_with_boots=banned
+
+	; Server Only
+	; 
+	; Campfires will cook entities without setting them on 
+	; fire. 
+	campfires_cook_entities=banned
+
+	; Server Only
+	; 
+	; Campfires will set fire to mobs standing on them, 
+	; therefore also cooking them. 
+	; 
+	campfires_ignite_entities=banned
+
+	; Server Only
+	; 
+	; Campfires are unlit when placed and must be lit with a 
+	; Flint and Steel. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/campfires_place_unlit.mp4
+	campfires_place_unlit=banned
+
+	; Server Only
+	; 
+	; Spawn eggs spawn cracking particles and play a sound 
+	; when used. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/cracking_spawn_eggs.mp4
+	cracking_spawn_eggs=banned
+
+	; Server Only
+	; 
+	; Ender pearls play enderman teleport sound when breaking.
+	; 
+	ender_pearl_sound=banned
+
+	; Server Only
+	; 
+	; Players will not lose air while underwater.
+	; 
+	extra.can_breathe_water=banned
+
+	; Server Only
+	; 
+	; Players cannot take fire damage.
+	; 
+	extra.fireproof=banned
+
+	; Client Only
+	; 
+	; ?
+	; 
+	extra.ghost_chest_woo_woo=banned
+
+	; Server Only
+	; 
+	; Players cannot be targeted by mobs at all. Sorta like 
+	; Apathetic Mobs. 
+	; 
+	extra.invisible_to_mobs=banned
+
+	; Server Only
+	; 
+	; Players never lose food, and when they eat food it 
+	; instead heals them directly. Sorta like Hunger Strike. 
+	; 
+	extra.no_hunger=banned
+
+	; Server Only
+	; 
+	; Prevents phantoms from spawning.
+	; 
+	extra.no_phantoms=banned
+
+	; Server Only
+	; 
+	; Prevents wandering traders from spawning.
+	; 
+	extra.no_wandering_trader=banned
+
+	; Server Only
+	; 
+	; Players always have Conduit Power.
+	; 
+	extra.permanent_conduit_power=banned
+
+	; Server Only
+	; 
+	; Players always have Dolphins Grace.
+	; 
+	extra.permanent_dolphins_grace=banned
+
+	; Server Only
+	; 
+	; Players will scare creepers.
+	; 
+	extra.scares_creepers=banned
+
+	; Server Only
+	; 
+	; Farmland will not get trampled when wearing feather 
+	; falling. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/feather_falling_no_trample.mp4
+	feather_falling_no_trample=banned
+
+	; Server Only
+	; 
+	; Cobwebs can burn.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/flammable_cobwebs.mp4
+	flammable_cobwebs=banned
+
+	; Client Only
+	; 
+	; Makes shields use the full-res banner patterns instead 
+	; of weird smaller versions. Compatible with custom patterns and 
+	; resource packs. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/fullres_banner_shields.mp4
+	fullres_banner_shields=banned
+
+	; Server Only
+	; 
+	; Makes ghasts randomly play the unused "scream" sound 
+	; when outside of the Nether. 
+	; 
+	ghast_panic=banned
+
+	; Client Only
+	; 
+	; Adjusts sign text colors to be less garbage.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/legible_signs.mp4
+	legible_signs=banned
+
+	; Client Only
+	; 
+	; Makes the "on fire" overlay half as tall, and removes it 
+	; completely if you have Fire Resistance.
+	; Especially nice with resource 
+	; packs like Faithful that have tall fire textures. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/less_annoying_fire.mp4
+	less_annoying_fire=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Allows note blocks to play if any 
+	; block next to them has a nonsolid face, instead of only if the block 
+	; above is air.
+	; On the client, just adjusts the note particle to fly 
+	; the right direction. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/less_restrictive_note_blocks.mp4
+	less_restrictive_note_blocks=banned
+
+	; Client Only
+	; 
+	; Plays the old longer level up sound when you reach level 
+	; 30. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/long_levelup_sound_at_30.mp4
+	long_levelup_sound_at_30=banned
+
+	; Server Only
+	; 
+	; Water evaporates when being placed inside a cauldron in 
+	; the nether. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/nether_cauldron.mp4
+	nether_cauldron=banned
+
+	; Server Only
+	; 
+	; Disables the generation of 1 block hidden lava pockets 
+	; in the Nether. They were initially added to discourage stripmining in 
+	; the Nether for quartz, but now that Netherite exists, which can only 
+	; be reasonably obtained via stripmining, it's just frustrating for no 
+	; real reason.
+	; "Dinnerlava" refers to the fact this was part of a 
+	; series of changes all made by Dinnerbone in a short span of time in 
+	; the 1.5 era mostly on provocation from Vechs of Super Hostile 
+	; fame.
+	; Will not take effect unless the world is reloaded. 
+	; 
+	no_dinnerlava=banned
+
+	; Server Only
+	; 
+	; Chest and hopper minecarts will not be slowed down 
+	; proportionally to the number of items in them. 
+	; 
+	no_heavy_minecarts=banned
+
+	; Server Only
+	; 
+	; Blocks which would normally not affect players when 
+	; sneaking will. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/no_sneak_bypass.mp4
+	no_sneak_bypass=banned
+
+	; Server Only
+	; 
+	; Farmland will not get trampled.
+	; 
+	no_trample=banned
+
+	; Client Only
+	; 
+	; Disables the fog brightening effect with Night Vision.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/normal_fog_with_night_vision.mp4
+	normal_fog_with_night_vision=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Allows sneaking when punching note 
+	; blocks to play them in Creative mode.
+	; On the client, prevents the 
+	; break effect from occurring as usually happens with server-side break 
+	; prevention. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/play_note_blocks_in_creative.mp4
+	play_note_blocks_in_creative=banned
+
+	; Client Only
+	; 
+	; Makes experience random colors instead of just lime 
+	; green. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/rainbow_experience.mp4
+	rainbow_experience=banned
+
+	; Client Only
+	; 
+	; Recipe book crafts items instead of moving them to the 
+	; crafting area. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/recipe_book_auto_craft.mp4
+	recipe_book_auto_craft=banned
+
+	; Server Only
+	; 
+	; Sneaking while tuning a note block reduces its pitch 
+	; rather than increases. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/reverse_note_block_tuning.mp4
+	reverse_note_block_tuning=banned
+
+	; Client Only
+	; 
+	; Allows players to see held items while riding entities 
+	; like boats. 
+	; 
+	see_items_while_riding=banned
+
+	; Server Only
+	; 
+	; Makes shulker bullets despawn when the shulker that shot 
+	; them is killed. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/shulker_bullets_despawn_on_death.mp4
+	shulker_bullets_despawn_on_death=banned
+
+	; Client Only
+	; 
+	; Makes minecarts silent.
+	; 
+	silent_minecarts=banned
+
+	; Server Only
+	; 
+	; Makes Loyalty tridents immune to void damage, and causes 
+	; them to start their return timer upon falling into the void. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/tridents_in_void_return.mp4
+	tridents_in_void_return=banned
+
+; Small additions to vanilla mechanics.
+; 
+[minor_mechanics]
+	; Server Only
+	; 
+	; Breaking cactus with your hand will damage you the same 
+	; as hugging it. 
+	; 
+	cactus_punching_hurts=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Makes Channeling II a valid 
+	; enchant that works while raining as well. 
+	; 
+	channeling_two=banned
+
+	; Server & Client
+	; 
+	; Adds a key to explicitly enter the "crawling" 
+	; stance. No more smushing yourself with a trapdoor. Needed on both the 
+	; server and client, but doesn't break vanilla clients.
+	; Honors the 
+	; vanilla "Sneak" Accessibility Option. Interacts with Utility > Toggle 
+	; Stance. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/crawling.mp4
+	crawling=banned
+
+	; Server Only
+	; 
+	; Right-clicking a note block with a stack of sticks sets 
+	; its pitch to the size of the stack minus one. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/exact_note_block_tuning.mp4
+	exact_note_block_tuning=banned
+
+	; Server Only
+	; 
+	; More accurately determines what the player is standing 
+	; on. e.g. with this you can't take fall damage on a slime block while 
+	; landing on an edge with air next to it. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/collision_based_landing_pos.mp4
+	extra.collision_based_landing_pos=banned
+
+	; Server Only
+	; 
+	; Pistons launch players up as if they were pushing slime 
+	; blocks. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/launching_pistons.mp4
+	extra.launching_pistons=banned
+
+	; Server Only
+	; 
+	; Observers detect when entities move in front of them if 
+	; they have no block in front of them. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/observers_see_entities.mp4
+	extra.observers_see_entities=banned
+
+		; Server Only
+		; 
+		; Observers only detect living entities, and not 
+		; e.g. item entities.
+		; Safety option to prevent breaking a 
+		; variety of vanilla contraptions. 
+		; 
+		extra.observers_see_entities_living_only=banned
+
+	; Server Only
+	; 
+	; Makes spiders unable to climb while wet. Basically a 
+	; more overpowered version of Spiders Can't Climb Glazed Terracotta. 
+	; May break vanilla spider farms.
+	; Interacts with Enhanced Moistness, 
+	; and the demo video uses it for the water splash to work like it does. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/spiders_cant_climb_while_wet.mp4
+	extra.spiders_cant_climb_while_wet=banned
+
+	; Server Only
+	; 
+	; Requires water_fills_on_break to have at least 2 water 
+	; sources. 
+	extra.water_fills_on_break_strict=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Makes Feather Falling V a valid 
+	; enchant that completely negates fall damage. Optionally does damage 
+	; to the boots.
+	; If present on the client, makes the enchantment 
+	; available in the Creative menu. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/feather_falling_five.mp4
+	feather_falling_five=banned
+
+		; Server Only
+		; 
+		; Makes absorbing fall damage with Feather Falling 
+		; V cause damage to the boots. 
+		; 
+		feather_falling_five_damages_boots=banned
+
+	; Server Only
+	; 
+	; Right-clicking a block with no action with a Fire Aspect 
+	; tool emulates a click with flint and steel, allowing you to light 
+	; fires and such with a Fire Aspect tool instead of having to carry 
+	; around flint and steel.
+	; Since it emulates clicking with a Flint and 
+	; Steel, it's highly compatible. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/fire_aspect_is_flint_and_steel.mp4
+	fire_aspect_is_flint_and_steel=banned
+
+	; Server Only
+	; 
+	; Fire Protection can be applied to any enchantable item, 
+	; and makes the item immune to fire and lava damage. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/fire_protection_on_any_item.mp4
+	fire_protection_on_any_item=banned
+
+	; Server Only
+	; 
+	; Allows furnace minecarts to accept any furnace fuel, 
+	; rather than just coal and charcoal. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/furnace_minecart_any_fuel.mp4
+	furnace_minecart_any_fuel=banned
+
+	; Server Only
+	; 
+	; Snow layers and slabs will be mined a layer at a time.
+	; 
+	gradual_block_breaking=banned
+
+	; Server Only
+	; 
+	; Makes Infinity bows not require an arrow in your 
+	; inventory to fire.
+	; If not present on client, firing bows with no 
+	; arrows is a bit janky. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/infibows.mp4
+	infibows=banned
+
+	; Server Only
+	; 
+	; Invisibility splash potions affect inanimates 
+	; (minecarts, arrows, etc) making them invisible. They will become 
+	; visible again if they become wet. This enables the vanilla 
+	; "invisible" flag, which doesn't work on inanimates unless Fixes > 
+	; Inanimates Can Be Invisible is also enabled.
+	; Logic: Invisibility 
+	; potions coat the outer surface of the object. Living entities absorb 
+	; and eventually eliminate the compound, and when drank it exudes from 
+	; the pores, but inanimate objects do not have metabolisms, so the 
+	; invisibility hangs around indefinitely unless washed off. Don't @ me 
+	; about skeletons. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/invisibility_splash_on_inanimates.mp4
+	invisibility_splash_on_inanimates=banned
+
+	; Server Only
+	; 
+	; Placing a block of wool adjacent to a dispenser, 
+	; dropper, or piston makes it silent. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/mechanism_muffling.mp4
+	mechanism_muffling=banned
+
+	; Server Only
+	; 
+	; Tells you the note the note block has been tuned to when 
+	; tuning it or playing it manually above your hotbar. Also shows the 
+	; octave, and shows the correct note for the snare and click 
+	; instruments. (The bass drum is hard to nail down and so does not show 
+	; note or octave info; if you know the best way to describe the bass 
+	; drum, please let me know in an issue.) 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/note_block_notes.mp4
+	note_block_notes=banned
+
+	; Server Only
+	; 
+	; Makes note blocks play when landed on. The higher the 
+	; entity fell, the louder the note will be. Also triggers Observers. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/note_blocks_play_on_landing.mp4
+	note_blocks_play_on_landing=banned
+
+	; Server Only
+	; 
+	; Protection can be applied to any enchantable item.
+	; It 
+	; will inclusively protect from:. Level 1: cactus, Level 2: fire, Level 
+	; 3: lava, Level 4: explosions. 
+	; 
+	protection_on_any_item=banned
+
+	; Server Only
+	; 
+	; Makes spiders unable to climb glazed terracotta, to make 
+	; farming them less of a chore if you go to the trouble to make glazed 
+	; terracotta.
+	; Logic: Slime blocks can't stick to glazed terracotta. Are 
+	; spiders really stickier than solid slime? 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/spiders_cant_climb_glazed_terracotta.mp4
+	spiders_cant_climb_glazed_terracotta=banned
+
+	; Server Only
+	; 
+	; Using bone meal on a stone block with a moss block 
+	; nearby grows moss to that block, to make it a bit easier to work with 
+	; for building. 
+	; 
+	spreadable_moss=banned
+
+	; Server Only
+	; 
+	; When a trident hits a lever it will toggle it.
+	; 
+	tridents_activate_levers=banned
+
+	; Server Only
+	; 
+	; Shift right click with an empty hand to retrieve a 
+	; saddle from a pig/strider. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/unsaddle_creatures.mp4
+	unsaddle_creatures=banned
+
+	; Server Only
+	; 
+	; Water source blocks fill in broken blocks instead of air 
+	; if there is more water on its north, east, south, west, and top faces 
+	; than there is air on its north, east, south, and west faces. In case 
+	; of a tie, air wins. Makes terraforming lakes and building canals, etc 
+	; much less frustrating. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/water_fills_on_break.mp4
+	water_fills_on_break=banned
+
+; New mechanics and powerful additions.
+; 
+[mechanics]
+	; Server Only
+	; 
+	; Allows right-clicking on an anvil with a Block of Iron 
+	; to repair it one stage. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/anvil_repair.mp4
+	anvil_repair=banned
+
+	; Server Only
+	; 
+	; Filling a glass bottle underwater refills 1 air bubble.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/bottled_air.mp4
+	bottled_air=banned
+
+	; Server Only
+	; 
+	; Makes gear drop its consituent items when broken. This 
+	; is completely configurable in 
+	; config/fabrication/gear_components.ini.
+	; Also works with nonplayer 
+	; entities, where it is affected by their drop chance table. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/broken_tools_drop_components.mp4
+	; See the default config for more info: https://github.com/unascribed/Fabrication/blob/trunk/src/main/resources/default_gear_components_config.ini
+	broken_tools_drop_components=banned
+
+	; Server Only
+	; 
+	; Allows using a comparator on a powered rail just like a 
+	; detector rail. Makes minecart logistics a lot easier. Also allows 
+	; using a repeater to do normal detection. 
+	; 
+	detecting_powered_rails=banned
+
+	; Server Only
+	; 
+	; Placing magenta glazed terracotta under a detector rail 
+	; makes it only detect minecarts moving in the direction of the arrow. 
+	; 
+	directional_detector_rails=banned
+
+	; Server Only
+	; 
+	; Placing magenta glazed terracotta under a powered rail 
+	; makes it push minecarts in the direction of the arrow, even from a 
+	; stop. They also work as hard stops for carts going the wrong 
+	; direction.
+	; Works similar to a Railcraft Boarding Track. 
+	; 
+	directional_powered_rails=banned
+
+	; Server Only
+	; 
+	; Entities are considered "wet" for 5 seconds after 
+	; leaving a source of wetness. Additionally, lingering or splash water 
+	; bottles inflict wetness. Also makes wet entities drip to show they're 
+	; wet. Affects various vanilla mechanics including fire and undead 
+	; burning.
+	; Touching lava instantly removes wetness, meaning lava blades 
+	; still work. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/enhanced_moistness.mp4
+	enhanced_moistness=banned
+
+	; Redstone on top of wool will not connect to redstone on top of a 
+	; different color of wool.
+	; Experimental. Once sufficiently tested, will 
+	; be moved out of Extra. 
+	; 
+	extra.colorful_redstone=banned
+
+	; Server Only
+	; 
+	; When adding enchants that would normally not be 
+	; compatible it will instead get added in an inactive state. 
+	; Conflicting enchants can be swapped on the go by shift right-clicking 
+	; the item. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/swap_conflicting_enchants.mp4
+	extra.swap_conflicting_enchants=banned
+
+	; Server Only
+	; 
+	; Pearls will teleport entities they hit and pull nearby 
+	; ones. 
+	extra.weaponized_pearls=banned
+
+	; Server & Client
+	; 
+	; Placing a book in the bottom slot of a Grindstone 
+	; when disenchanting an item will transfer the enchantments onto the 
+	; book.
+	; Doesn't work properly if the client doesn't also have it, but 
+	; it will not break vanilla clients. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/grindstone_disenchanting.mp4
+	grindstone_disenchanting=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Empty bottles can be used to 
+	; collect "Obsidian Tears" from Crying Obsidian. When quaffed by or 
+	; dispensed onto a player, it updates their spawn to the location of 
+	; the block the tears are from. Dispensers can also be used to fill 
+	; empty bottles with tears.
+	; Crying Obsidian respawn works in any 
+	; dimension and doesn't need to be recharged, but you spawn with half 
+	; health, no saturation, less than full food, and Weakness.
+	; On client, 
+	; just gives the bottle a custom appearance instead of a potion item. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/obsidian_tears.mp4
+	obsidian_tears=banned
+
+	; Server Only
+	; 
+	; Adds "Pursurvers", observers with a Purpur block next to 
+	; them, that can detect left-clicks on their watched block. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/pursurvers.mp4
+	pursurvers=banned
+
+	; Server Only
+	; 
+	; Slow fall splash potions affect inanimates (minecarts, 
+	; arrows, etc) making them unaffected by gravity. They will become 
+	; normally affected again if they become wet.
+	; This is kind of 
+	; overpowered. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/slowfall_splash_on_inanimates.mp4
+	slowfall_splash_on_inanimates=banned
+
+	; Server Only
+	; 
+	; Powered rails stop furnace carts when appropriate and 
+	; conserve their fuel. 
+	; 
+	toggleable_furnace_carts=banned
+
+	; Server Only
+	; 
+	; Sheep wool slightly reduces some types of damage.
+	; 
+	wool_protected_sheep=banned
+
+; Changes to vanilla balance.
+; 
+[balance]
+	; Server Only
+	; 
+	; Anvils don't become "Too Expensive".
+	; 
+	anvil_no_level_limit=banned
+
+	; Server Only
+	; 
+	; Makes renaming an item on an anvil always cost one 
+	; level. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/anvil_rename_always_costs_one.mp4
+	anvil_rename_always_costs_one=banned
+
+	; Server Only
+	; 
+	; Makes the Impaling enchantment act like it does in 
+	; Bedrock Edition and Combat Test 4. Namely, it deals bonus damage to 
+	; anything that is in water or rain (i.e. is wet), instead of only 
+	; aquatic mobs.
+	; Interacts with Enhanced Moistness. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/bedrock_impaling.mp4
+	bedrock_impaling=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Disables the anvil prior work 
+	; penalty when an item has been worked multiple times. Makes 
+	; non-Mending tools relevant by allowing you to repair them 
+	; indefinitely, and makes putting books on tools easier.
+	; If only on the 
+	; server and not the client, the wrong level cost will briefly be 
+	; displayed before being corrected. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/disable_prior_work_penalty.mp4
+	disable_prior_work_penalty=banned
+
+	; Server Only
+	; 
+	; Players drop 80% of their experience when dying instead 
+	; of basically nothing. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/drop_more_exp_on_death.mp4
+	drop_more_exp_on_death=banned
+
+	; Server Only
+	; 
+	; Creeper explosions deal entity damage, but not block 
+	; damage, even if mobGriefing is true. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/environmentally_friendly_creepers.mp4
+	environmentally_friendly_creepers=banned
+
+	; Server Only
+	; 
+	; Anvils only take damage when falling from a height 
+	; rather than randomly after being used. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/anvil_damage_only_on_fall.mp4
+	extra.anvil_damage_only_on_fall=banned
+
+	; Server Only
+	; 
+	; Any item repair in the anvil will restore item 
+	; durability. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/anvil_full_repair.mp4
+	extra.anvil_full_repair=banned
+
+	; Server Only
+	; 
+	; Anvils don't cost any xp.
+	; 
+	extra.anvil_no_xp_cost=banned
+
+	; Server Only
+	; 
+	; Causes explosions to always break shields.
+	; 
+	extra.brittle_shields=banned
+
+	; Server Only
+	; 
+	; Prevents using Elytra.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/disable_elytra.mp4
+	extra.disable_elytra=banned
+
+	; Server Only
+	; 
+	; Prevent Elytra boosting using firework rockets.
+	; 
+	extra.disable_elytra_boost=banned
+
+	; Server Only
+	; 
+	; Stops the mending enchantment from working.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/disable_mending.mp4
+	extra.disable_mending=banned
+
+	; Server Only
+	; 
+	; Stops new villagers from offering mending.
+	; 
+	extra.disable_mending_trade=banned
+
+	; Server Only
+	; 
+	; Ender pearls forget who threw them when being unloaded. 
+	; Which means saving a ender pearl in a bubble column becomes more 
+	; difficult. 
+	extra.disable_pearl_stasis=banned
+
+	; Server Only
+	; 
+	; Ender dragon always spawn a dragon egg when killed.
+	; 
+	extra.ender_dragon_always_spawn_egg=banned
+
+	; Server Only
+	; 
+	; Ender dragon always gives the same xp amount as it would 
+	; the first time. 
+	; 
+	extra.ender_dragon_full_xp=banned
+
+	; Server Only
+	; 
+	; Shields half non-projectile damage instead of blocking 
+	; it. 
+	extra.faulty_shields=banned
+
+	; Server Only
+	; 
+	; Allows players to eat unconditionally.
+	; 
+	extra.food_always_edible=banned
+
+	; Server Only
+	; 
+	; Makes Mending and Infinity compatible enchantments.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/infinity_mending.mp4
+	extra.infinity_mending=banned
+
+	; Server Only
+	; 
+	; Taking more then a heart of damage interrupts the 
+	; current action of any mob / player. 
+	; 
+	extra.interrupting_damage=banned
+
+	; Server Only
+	; 
+	; Makes furnace minecarts load chunks if they have fuel.
+	; 
+	extra.loading_furnace_minecart=banned
+
+	; Server Only
+	; 
+	; All ingot mob drops are converted to nuggets where 
+	; possible, otherwise voided. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/mobs_dont_drop_ingots.mp4
+	extra.mobs_dont_drop_ingots=banned
+
+	; Server Only
+	; 
+	; Arrows shot by skeletons can be picked up.
+	; 
+	extra.pickup_skeleton_arrows=banned
+
+	; Server Only
+	; 
+	; Mob spawners don't require a player nearby to spawn. 
+	; This can be dangerous on a normal world as it means all loaded 
+	; spawners will constantly spawn mobs, which makes dungeons pre-loaded 
+	; monsterboxes and floods abandoned mineshafts with cave spiders. Use 
+	; carefully, preferably in worlds with structures disabled.
+	; See Balance 
+	; > Spawners Always Tick for a less extreme, safer version of this. 
+	; 
+	extra.player_free_spawners=banned
+
+	; Server Only
+	; 
+	; Prevents dragon egg from teleporting.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/static_dragon_egg.mp4
+	extra.static_dragon_egg=banned
+
+	; Server & Client
+	; 
+	; Allows storing up to 8 nonstackable items in a 
+	; bundle, as long as nothing else is stored. 
+	; 
+	extra.tools_in_bundles=banned
+
+	; Server & Client
+	; 
+	; Makes obsidian and obsidian-related blocks break 3× 
+	; faster. Needed on both sides to work properly.
+	; Does not break vanilla 
+	; clients when on the server, but when on the client, vanilla servers 
+	; will think you're cheating. (And they won't be wrong.) 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/faster_obsidian.mp4
+	faster_obsidian=banned
+
+	; Server Only
+	; 
+	; Makes furnace minecarts very fast and burn fuel more 
+	; quickly.
+	; An attempt to make rail transport relevant again, as well as 
+	; furnace carts, in a world with ice roads, swimming, elytra, 
+	; etc.
+	; Warning: These carts are so fast that they sometimes fall off of 
+	; track corners. Make sure to surround track corners with blocks. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/hyperspeed_furnace_minecart.mp4
+	hyperspeed_furnace_minecart=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Allow putting Infinity on 
+	; crossbows. Only works for plain arrows.
+	; Honors InfiBows. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/infinity_crossbows.mp4
+	infinity_crossbows=banned
+
+	; Server Only
+	; 
+	; Makes running on soul blocks with Soul Speed not deal 
+	; damage to your boots. 
+	; 
+	soul_speed_doesnt_damage_boots=banned
+
+	; Server Only
+	; 
+	; Spawners always count down their spawn timers, even if 
+	; no player is nearby. This means a spawner that is left alone for a 
+	; while will spawn *instantly* when a player comes in range. Allows 
+	; shuttling a player between spawners with a minecart or water stream 
+	; to efficiently make use of spawners that are close together, but not 
+	; quite close enough to all be activated at the same time. 
+	; 
+	spawners_always_tick=banned
+
+	; Server Only
+	; 
+	; Allows tridents to accept the Power enchantment, 
+	; increasing their ranged damage. It's pitiful that tridents only deal 
+	; as much damage as an unenchanted bow and this cannot be improved at 
+	; all other than via Impaling, which is exclusive to aquatic mobs; 
+	; notably, Drowned do not count as aquatic mobs. Only the harmless 
+	; squids, salmon, cod, tropical fish, and the less harmless pufferfish 
+	; and guardians count as "aquatic".
+	; Power is considered incompatible 
+	; with Sharpness and Impaling. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/tridents_accept_power.mp4
+	tridents_accept_power=banned
+
+	; Server Only
+	; 
+	; Allows tridents to accept the Sharpness enchantment, 
+	; increasing their melee damage. See above for justification. Tridents 
+	; deal 1 more damage than a Netherite Sword, but this tweak *only* 
+	; allows them to accept Sharpness; no Smite, no Looting, etc.
+	; Sharpness 
+	; is considered incompatible with Power and Impaling. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/tridents_accept_sharpness.mp4
+	tridents_accept_sharpness=banned
+
+; Opinionated changes.
+; 
+[weird_tweaks]
+	; Server Only
+	; 
+	; Blaze powder behaves as bone meal for nether wart.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/blaze_fertilizer.mp4
+	blaze_fertilizer=banned
+
+	; Server Only
+	; 
+	; Creepers explode after taking explosion damage.
+	; 
+	chaining_creepers=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; By default, makes breaking nether 
+	; blocks deal 50x damage to non-golden and non-netherite tools, and 
+	; makes golden tools take 1/50th the damage when breaking the same 
+	; blocks, bringing their durability just above diamond. Also makes 
+	; wooden tools crafted with nether planks into "Fungal" tools, and 
+	; stone tools crafted with blackstone into "Blackstone" tools, which 
+	; also get the 1/50th damage bonus. Completely configurable; see 
+	; config/fabrication/dimensional_tools.ini.
+	; On client, adjusts tooltips 
+	; to show fractional damage.
+	; Inspired by a joke video. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/gold_tools_useful_in_nether.mp4
+	; See the default config for more info: https://github.com/unascribed/Fabrication/blob/trunk/src/main/resources/default_dimensional_tools_config.ini
+	dimensional_tools=banned
+
+	; Server or Client
+	; 
+	; Disables the unnecessary "Gear equips" sound that 
+	; plays when your hands change, and is often glitchily played every 
+	; tick. Armor equip sounds and other custom equip sounds remain 
+	; unchanged. You won't even notice it's gone.
+	; On client, mutes it just 
+	; for you.
+	; On server, prevents the sound from playing at all for 
+	; everyone. 
+	disable_equip_sound=banned
+
+	; Client Only
+	; 
+	; Removes thick nether fog.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/disable_nether_fog.mp4
+	disable_nether_fog=banned
+
+	; Server Only
+	; 
+	; If keepInventory is enabled, players still drop their 
+	; experience when dying, but do so losslessly. Incents returning to 
+	; where you died even when keepInventory is enabled. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/drop_exp_with_keepinventory.mp4
+	drop_exp_with_keep_inventory=banned
+
+	; Server Only
+	; 
+	; Endermen no longer place or pickup blocks.
+	; 
+	endermen_dont_grief=banned
+
+	; Server or Client
+	; 
+	; Makes Endermen not make their growling or 
+	; screeching sounds when angry.
+	; On client, mutes the sounds for just 
+	; you. This means angry endermen don't make ambient sounds.
+	; On server, 
+	; replaces the angry ambient sound with the normal ambient sound for 
+	; everyone. The stare sound is client-sided, unfortunately. 
+	; 
+	endermen_dont_squeal=banned
+
+	; Server Only
+	; 
+	; Causes creepers to light their fuses when lit on fire. 
+	; Just because. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/creepers_explode_when_on_fire.mp4
+	extra.creepers_explode_when_on_fire=banned
+
+	; Server Only
+	; 
+	; Piglins and hoglins can be made immune with a golden 
+	; apple or cured if they also have weakness. 
+	; 
+	extra.curable_piglins=banned
+
+	; Server Only
+	; 
+	; Prevents lightning from creating fire.
+	; 
+	extra.disable_lightning_fire=banned
+
+	; Server Only
+	; 
+	; Prevents beds from skipping the night.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/disable_night_skip.mp4
+	extra.disable_night_skip=banned
+
+	; Server Only
+	; 
+	; Emeralds spawn in all biomes which have ores.
+	; 
+	extra.encroaching_emeralds=banned
+
+	; Server Only
+	; 
+	; Tripwire breaks after being activated.
+	; 
+	extra.flimsy_tripwire=banned
+
+	; Client Only
+	; 
+	; Creepers will take on the foliage color of the biome 
+	; they're in. 
+	; 
+	extra.foliage_creepers=banned
+
+	; Server Only
+	; 
+	; Prevents dolphins from picking up items.
+	; 
+	extra.no_dolphin_theft=banned
+
+	; Server Only
+	; 
+	; Creepers burn in sunlight. Very dangerous in combination 
+	; with Creepers Explode When On Fire.
+	; Takes precedence over 
+	; Photoresistant Mobs if that is also enabled, allowing you to make 
+	; only creepers burn in sunlight. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/photoallergic_creepers.mp4
+	extra.photoallergic_creepers=banned
+
+	; Server Only
+	; 
+	; Mobs don't burn in sunlight.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/photoresistant_mobs.mp4
+	extra.photoresistant_mobs=banned
+
+	; Server Only
+	; 
+	; Allows entities to take damage multiple times if it's 
+	; from multiple sources. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/source_dependent_iframes.mp4
+	extra.source_dependent_iframes=banned
+
+	; Server Only
+	; 
+	; Throwing an bucket at a lava cauldron will pickup the 
+	; lava. 
+	extra.thrown_buckets_empty_lava_cauldrons=banned
+
+	; Server Only
+	; 
+	; TNT and other explosives do block damage even 
+	; underwater. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/underwater_explosions.mp4
+	extra.underwater_explosions=banned
+
+	; Server Only
+	; 
+	; Instead of restocking villagers will completely reset 
+	; their trades. This also soft-limits the trades to the villager's 
+	; level (one trade of each level). 
+	; 
+	extra.villager_trades_reset=banned
+
+	; Server Only
+	; 
+	; Villagers will follow players holding emerald blocks.
+	; 
+	extra.villagers_follow_emerald_blocks=banned
+
+	; Server Only
+	; 
+	; Drops from blocks and entities are instantly placed in 
+	; your inventory if there's room. This is animated and everything. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/instant_pickup.mp4
+	instant_pickup=banned
+
+	; Server Only
+	; 
+	; Items don't get destroyed by cactus blocks.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/item_safe_cactus.mp4
+	item_safe_cactus=banned
+
+	; Server Only
+	; 
+	; Grass and tall grass can be placed on leaves.
+	; Using Bone 
+	; Meal on leaves makes them grow grass. 
+	; 
+	leaves_grow_grass=banned
+
+	; Server Only
+	; 
+	; Players falling into the void teleports them back to the 
+	; last place they were on the ground and deals 6 hearts of unblockable 
+	; void damage. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/repelling_void.mp4
+	repelling_void=banned
+
+	; Client Only
+	; 
+	; Allows players to use items and attack while riding 
+	; entities like boats. 
+	; 
+	use_items_while_riding=banned
+
+; Forward ports of forgotten tidbits.
+; 
+[woina]
+	; Client Only
+	; 
+	; Back in Survival Test, drops blinked white to make them 
+	; stand out more. This is an implementation of that.
+	; If Utility > 
+	; Despawning Items Blink is enabled, that tweak's disappear-flashing 
+	; will be disabled, and instead this tweak's white flashing will get 
+	; faster and faster as despawn approaches. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/blinking_drops.mp4
+	; Survival Test video, for reference: https://unascribed.com/fabrication/survival_test.mp4
+	blinking_drops=banned
+
+	; Client Only
+	; 
+	; Resurrects the Beta 1.2-era animated falling block logo. 
+	; Because it looked sweet and it is shameful they removed it.
+	; The block 
+	; logo is completely customizable in config/fabrication/block_logo.png 
+	; and config/fabrication/block_logo.ini. The default is identical to 
+	; how it was in Beta 1.2. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/block_logo.mp4
+	block_logo=banned
+
+	; Client Only
+	; 
+	; Back in Survival Test, likely in the interest of keeping 
+	; a consistent pixel density in the world, block drops were drawn with 
+	; an 8x8 portion of the block texture. This didn't always work well 
+	; back then, and rather than fix things up and design textures with it 
+	; in mind, it was simply removed.
+	; This option uses a whitelist in 
+	; config/fabrication/classic_block_drops.ini to emulate the old 
+	; behavior, and for anything not whitelisted, uses mipmapped 
+	; textures.
+	; This looks pretty neat. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/classic_block_drops.mp4
+	; Survival Test video, for reference: https://unascribed.com/fabrication/survival_test.mp4
+	classic_block_drops=banned
+
+	; Server Only
+	; 
+	; When dropping items of the same type they don't merge 
+	; into a bigger stack. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/dropped_items_dont_stack.mp4
+	dropped_items_dont_stack=banned
+
+	; Client Only
+	; 
+	; Old end portal texture, may not be entirely accurate. 
+	; Will not work unless the game is restarted, requires legacy GL and 
+	; may not work on some systems. 
+	; 
+	end_portal_parallax=banned
+
+	; Client Only
+	; 
+	; Brings back billboarded flat item drops like on Fast 
+	; graphics prior to 1.8 or like always prior to 1.4. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/billboard_drops.mp4
+	extra.billboard_drops=banned
+
+	; Client Only
+	; 
+	; Replaces the panorama background of the title screen 
+	; with the old dirt one. 
+	; 
+	extra.dirt_screen=banned
+
+	; Client Only
+	; 
+	; Brings back Indev flat first-person item models.
+	; "Why?" 
+	; Why not. 
+	; 
+	; 
+	; Demonstration image: https://unascribed.com/fabrication/flat_items.png
+	extra.flat_items=banned
+
+	; Server Only
+	; 
+	; Enchanting consumes all of the xp required for an 
+	; enchant. For example a 30 level enchant will consume 30 levels 
+	; instead of 3. 
+	; 
+	extra.full_enchanting_cost=banned
+
+	; Server Only
+	; 
+	; Bow fires arrows instantly upon clicking.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/instant_bow.mp4
+	extra.instant_bow=banned
+
+	; Server Only
+	; 
+	; Eating food is instant.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/instant_eat.mp4
+	extra.instant_eat=banned
+
+	; Client Only
+	; 
+	; Brings back Survival Test arm rotation.
+	; "Why?" Why not.
+	; 
+	; 
+	; Demonstration image: https://unascribed.com/fabrication/janky_arm.png
+	; Survival Test video, for reference: https://unascribed.com/fabrication/survival_test.mp4
+	extra.janky_arm=banned
+
+	; Server & Client (Client Optional)
+	; 
+	; Removes experience. Anvils become 
+	; free and enchanting only costs lapis. 
+	; 
+	extra.no_experience=banned
+
+	; Client Only
+	; 
+	; Prevents first-person hands from gradually transitioning 
+	; from the last camera position. 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/no_hand_sway.mp4
+	extra.no_hand_sway=banned
+
+	; Client Only
+	; 
+	; Players stay upright when killed.
+	; 
+	extra.no_player_death_animation=banned
+
+	; Server Only
+	; 
+	; Disable sprinting.
+	; 
+	extra.no_sprint=banned
+
+	; Client Only
+	; 
+	; Removes the gradual crouch / crawl camera transition.
+	; 
+	extra.no_stance_transition=banned
+
+	; Server Only
+	; 
+	; Disable swimming.
+	; 
+	extra.no_swim=banned
+
+	; Server Only
+	; 
+	; Sheep drop wool when punched.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/old_sheep_shear.mp4
+	extra.old_sheep_shear=banned
+
+	; Client Only
+	; 
+	; Ressurects the old inventory tooltip from the beta days.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/old_tooltip.mp4
+	extra.old_tooltip=banned
+
+	; Client Only
+	; 
+	; Brings back the old "Oof" hurt sound. Unlike the 
+	; resource pack approach, this is player-specific rather than replacing 
+	; the generic fleshy damage sound, so it won't result in random things 
+	; Oof-ing. 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/oof.mp4
+	extra.oof=banned
+
+	; Client Only
+	; 
+	; Returns void fog from pre 1.8.
+	; 
+	extra.void_fog=banned
+
+	; Client Only
+	; 
+	; Adds smoke and poof particles to explosions.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/more_explosion_particles.mp4
+	more_explosion_particles=banned
+
+	; Server Only
+	; 
+	; All armor has the same protection.
+	; 
+	old_armor=banned
+
+	; Server Only
+	; 
+	; Armor value is reduced with durability.
+	; 
+	old_armor_scale=banned
+
+	; Client Only
+	; 
+	; Inventories, pause and other menus will have a blue 
+	; gradient. 
+	old_background_shade=banned
+
+	; Client Only
+	; 
+	; Resurrects the old procedural lava texture from 1.4. 
+	; Replace your molten cheese with pasta sauce today! HAYO! 
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/old_lava.mp4
+	old_lava=banned
+
+	; Client Only
+	; 
+	; Returns void fog particles from pre 1.8.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/void_fog_particles.mp4
+	void_fog_particles=banned
+
+	; Client Only
+	; 
+	; Hovered buttons will have yellow text.
+	; 
+	; 
+	; Demonstration video: https://unascribed.com/fabrication/yellow_button_hover.mp4
+	yellow_button_hover=banned
+
+; QoL changes that make cheating easier.
+; 
+[unsafe]
+	; Server Only
+	; 
+	; Server will not check if the client is cheating, when 
+	; breaking blocks faster then expected.
+	; Helpful with block breaking lag 
+	; when you trust the players. 
+	; 
+	disable_breaking_speed_check=banned
+
+	; Server Only
+	; 
+	; Server will not check if the client is cheating, when 
+	; traveling faster then expected.
+	; Helpful with rubber banding when you 
+	; trust the players. 
+	; 
+	disable_moved_too_quickly=banned
+
+; Fixes for non-problems.
+; 
+[pedantry]
+	; Server Only
+	; 
+	; Creepers can no longer climb climbable blocks.
+	; 
+	creepers_cant_climb=banned
+
+	; Server Only
+	; 
+	; Entities can no longer climb climbable blocks (mostly 
+	; applies to ladders). This on it's own disables ladders, the feature 
+	; is intended to be used by other features. 
+	; 
+	entities_cant_climb=banned
+
+	; Client Only
+	; 
+	; Oak trees become apple trees. Because oak trees do not 
+	; grow apples. 
+	; 
+	; 
+	; Demonstration image: https://unascribed.com/fabrication/oak_is_apple.png
+	oak_is_apple=banned
+
+	; Client Only
+	; 
+	; TNT is renamed to Dynamite and doesn't say TNT on it. 
+	; TNT is more stable than Minecraft's representation of it, and the 
+	; texture is clearly dynamite.
+	; (Technically dynamite is made from 
+	; nitroglycerin, but nitro is so incredibly unstable that you would 
+	; need to change a dozen different mechanics to make it 
+	; "correct".)
+	; Gunpowder is also renamed to Creeper Dust, because 
+	; gunpowder is not that explosive. 
+	; 
+	; 
+	; Demonstration image: https://unascribed.com/fabrication/tnt_is_dynamite.png
+	tnt_is_dynamite=banned
+
+; Bad ideas given form.
+; 
+[experiments]
+	; Client Only
+	; 
+	; Prevents the game from manually modifying the window 
+	; position. So if you have custom configs or something that memorizes 
+	; window positions, they will be honored instead of the window always 
+	; being centered. 
+	; 
+	no_set_window_pos=banned
+
+	; Client Only
+	; 
+	; Disables rounding of atlases to the next power-of-two. 
+	; GPU drivers have supported "NPOT" textures since forever.
+	; Possibly 
+	; reduces VRAM usage. May reduce performance. Might cause 
+	; incompatibilites. 
+	packed_atlases=banned
+
+
+; Notices: (Do not edit anything past this line; it will be overwritten)
+; - No notices. You're in the clear!

--- a/index.toml
+++ b/index.toml
@@ -5,6 +5,10 @@ file = "config/NoChatReports/NCR-Client.json"
 hash = "11981fe269d7c1d231b65d2db484b1ee4f1077e32d6f8cccbcb2ff324d789063"
 
 [[files]]
+file = "config/fabrication/features.ini"
+hash = "344f8ad6c49f96f0d057b0bb63549ee85aad179b5a87f94a682020776f0eac7f"
+
+[[files]]
 file = "config/midnightlib.json"
 hash = "45421bbd126a17358dce57fda4e7bc3153f503e7c3f2909f20ebef86e0774a89"
 
@@ -204,6 +208,11 @@ metafile = true
 [[files]]
 file = "mods/ethicalmeatfields.pw.toml"
 hash = "e784483f27b62bec6e98f86a613236c53cd9de99fcf8cc85c661816f73f7cc47"
+metafile = true
+
+[[files]]
+file = "mods/fabrication.pw.toml"
+hash = "c4c771449e4fec227ee6d0477c2d32dbdcd8a0e3f9675140e53222363eda7112"
 metafile = true
 
 [[files]]

--- a/mods/fabrication.pw.toml
+++ b/mods/fabrication.pw.toml
@@ -1,0 +1,13 @@
+name = "Fabrication"
+filename = "fabrication-3.0.2+1.19.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/B3Eg0WhA/versions/3.0.2+1.19/fabrication-3.0.2%2B1.19.jar"
+hash-format = "sha1"
+hash = "4685a4dafe7d34f49beeb178168031075f3a5eee"
+
+[update]
+[update.modrinth]
+mod-id = "B3Eg0WhA"
+version = "mG7iW4Gr"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "440a736fc74136a398a9133a193f8be5d642642e03f1b1a7ef436bb7281ae9be"
+hash = "67a7cb8c58a5a11afecce5e1885f1c5596eff229d2699e3dc9f551b73d2420f4"
 
 [versions]
 minecraft = "1.19.2"

--- a/scripts/override_add.json
+++ b/scripts/override_add.json
@@ -15,6 +15,7 @@
   {"slug": "emi",                     "comment": "utility"},
   {"slug": "wthit",                   "comment": "utility"},
   {"slug": "no-chat-reports",         "comment": "utility"},
+  {"slug": "fabrication",             "comment": "utility"},
   {"slug": "spark",                   "version_id": "Biivc7P1", "comment": "utility"},
   {"slug": "yttr",                    "comment": "building"},
   {"slug": "aurorasdecorations",      "comment": "building"},


### PR DESCRIPTION
Most features are set to `banned`, and runtime config is disabled, meaning most mixins aren't loaded to my understanding.

Features that are enabled:
 - `multiline_sign_paste` - allows copying and pasting the whole contents of signs (saves lives using picturesign)
 - `use_player_list_name_in_tag` - uses nicknames above player heads, y'know, for drogtor.
 - `ping_privacy` - prevents user list scraping.