### PR TITLE
Disable breaking speed check and "moved too quickly"

### DIFF
--- a/config/fabrication/features.ini
+++ b/config/fabrication/features.ini
@@ -2209,7 +2209,7 @@
 	; Helpful with block breaking lag 
 	; when you trust the players. 
 	; 
-	disable_breaking_speed_check=banned
+	disable_breaking_speed_check=true
 
 	; Server Only
 	; 
@@ -2218,7 +2218,7 @@
 	; Helpful with rubber banding when you 
 	; trust the players. 
 	; 
-	disable_moved_too_quickly=banned
+	disable_moved_too_quickly=true
 
 ; Fixes for non-problems.
 ; 


### PR DESCRIPTION
Disabling "moved too quickly" fixes moovy being jittery at times
Disabling the breaking speed check is whatever