### PR TITLE
Update Jar It! 0.1.10 -> 0.1.11

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -277,7 +277,7 @@ metafile = true
 
 [[files]]
 file = "mods/jar-it.pw.toml"
-hash = "c5336ac93fa1998d27d832ee757a263e97a00d63bc9eb2a35cbe1fc74ed831cc"
+hash = "ee413b3ea2c3f2ed3adda268dfe32473fac7d245690f8d0e135bcaddaf4025f6"
 metafile = true
 
 [[files]]

--- a/mods/jar-it.pw.toml
+++ b/mods/jar-it.pw.toml
@@ -1,13 +1,13 @@
 name = "Jar It!"
-filename = "jar-it-0.1.10+1.19.2.jar"
+filename = "jar-it-0.1.11+1.19.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/o6qDedG5/versions/Is4FvGmc/jar-it-0.1.10%2B1.19.2.jar"
+url = "https://cdn.modrinth.com/data/o6qDedG5/versions/Gjp5k6xA/jar-it-0.1.11%2B1.19.2.jar"
 hash-format = "sha1"
-hash = "488e90cf49c20d01d8095e532a4e89b7e1958a6b"
+hash = "b13ca3ee9e8eb02da0b59b53eb3ec954b584c8cd"
 
 [update]
 [update.modrinth]
 mod-id = "o6qDedG5"
-version = "Is4FvGmc"
+version = "Gjp5k6xA"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0748a5c53e8db537ac4990b5a89c0aa0848d3331f5b01ffe2bb705b13fffe431"
+hash = "d982ad90c475571318c81b2c0640fed167051dad3adaac5d2cde7704fbd06509"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
# This PR
This PR updates Jar It! to add jar locking functionality, preventing people from accidentally opening jars.

# Testing
The new Jar It! version has been tested with the other mods in the pack on a local Modfest: Singularity testing server.