### PR TITLE
Update RecoveryPlus to version 0.3.0

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -462,7 +462,7 @@ metafile = true
 
 [[files]]
 file = "mods/recovery-plus.pw.toml"
-hash = "90d6e7adaf265d6b90fb5eef0138b18befb4d00d41344d5a6046148cc37c66fb"
+hash = "64897dab2767854d4bea60042f97a20be253893fc0b15a1ce9ccfeabc39e80a9"
 metafile = true
 
 [[files]]

--- a/mods/recovery-plus.pw.toml
+++ b/mods/recovery-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Recovery+"
-filename = "recovery_plus-0.2.2+1.19.jar"
+filename = "recovery_plus-0.3+1.19.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/DU7GOxKZ/versions/Z33AyeTZ/recovery_plus-0.2.2%2B1.19.jar"
+url = "https://cdn.modrinth.com/data/DU7GOxKZ/versions/F7kTwdqo/recovery_plus-0.3%2B1.19.jar"
 hash-format = "sha1"
-hash = "564963e41205ec7befd7fd52b23d65f0b1c7f5b1"
+hash = "44bbf8a286cf6858f29c0903c777bec5b220d53a"
 
 [update]
 [update.modrinth]
 mod-id = "DU7GOxKZ"
-version = "Z33AyeTZ"
+version = "F7kTwdqo"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "414111736c637214f3db4c34934c83b419b0401567d65dcea03e5bea1b21ef31"
+hash = "cc8269e2e7825d0945ecefd29715ea7d1d080975fdb3959f3658d23ef701ec6c"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
Fixes outdated waypoints being announced on the actionbar
Adds a Modfest specific pressure plate clearing any currently stored waypoints (only necessary if any other booth uses Nether Portals / End Gateways)